### PR TITLE
Fix LolayMultiTracker.logPage(name:withDictionary)

### DIFF
--- a/Sources/LolayInvestigo/LolayMultipleTracker.swift
+++ b/Sources/LolayInvestigo/LolayMultipleTracker.swift
@@ -85,7 +85,7 @@ public class LolayMultipleTracker: LolayBaseTracker {
     
     override public func logPage(_ name: String, withDictionary dictionary: [String:String]) {
         for tracker in trackers {
-            tracker.logEvent(name, withDictionary: dictionary)
+            tracker.logPage(name, withDictionary: dictionary)
         }
     }
     


### PR DESCRIPTION
The LolayMultiTracker.logPage method was chaining to the logEvent methods on it's list of trackers instead of the logPage method.

This PR changes it to logPage.

