### PR TITLE
Change LolayFirebaseTracker logPage(_:withDictionary) to send the correct event name for screen views.

### DIFF
--- a/Sources/LolayInvestigo/LolayFirebaseTracker.swift
+++ b/Sources/LolayInvestigo/LolayFirebaseTracker.swift
@@ -53,6 +53,6 @@ public class LolayFirebaseTracker: LolayBaseTracker {
     
     override public func logPage(_ name: String, withDictionary dictionary: [String:String]) {
         let parameters = dictionary.merging([AnalyticsParameterScreenName: name + "_page"]) { _, new in new }
-        Analytics.logEvent(AnalyticsParameterScreenName, parameters: parameters)
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: parameters)
     }
 }


### PR DESCRIPTION
The Firebase tracker  was logging page view withDictionary as regular events do to the event name being passed as `AnalyticsParameterScreenName` instead of `AnalyticsEventScreenView`.  This PR corrects the issue.